### PR TITLE
Add .journal.txt as another possible file extension.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
         ],
         "extensions": [
           ".hledger",
-          ".journal"
+          ".journal",
+          ".journal.txt"
         ],
         "configuration": "./language-configuration.json"
       }


### PR DESCRIPTION
I use `.journal.txt` as my ledger filename. This allows my operating
systems to display previews of the file in the file explorer, and also
lets me quickly open a text editor, even if VSCode, etc. is not
installed.

I also feel like I saw this as an example file extension at some point,
either on hledger.org, plaintextaccounting.org, or ledger-cli.org...
however, I can no longer see this example.