### PR TITLE
Differentiate line, inline, and block comments

### DIFF
--- a/syntaxes/hledger.tmLanguage.json
+++ b/syntaxes/hledger.tmLanguage.json
@@ -64,6 +64,11 @@
 			"patterns": [
 				{
 					"name": "comment.line",
+					"begin": "^[#;\\*]",
+					"end": "$"
+				},
+				{
+					"name": "comment.inline",
 					"begin": "[#;]",
 					"end": "$",
 					"patterns": [
@@ -72,6 +77,11 @@
 							"match": "[-\\w]+:[^,]*"
 						}
 					]
+				},
+				{
+					"name": "comment.blocks",
+					"begin": "^comment$",
+					"end": "^end comment$"
 				}
 			]
 		},


### PR DESCRIPTION
`hledger` supports asterisks as a comment starter, but only for standalone comments not attached to any specific posting. This is written here: https://hledger.org/1.28/hledger.html#payee-and-note

In addition, `hledger` supports block comments, documented here: https://hledger.org/1.28/hledger.html#comment-blocks

This PR changes the parse syntax to support both of these. I have tested this locally, I hope you can accept it! :)