### PR TITLE
Only try to deploy when tags are made

### DIFF
--- a/.github/workflows/deploy-to-vsx.yml
+++ b/.github/workflows/deploy-to-vsx.yml
@@ -1,8 +1,8 @@
 name: Deploy to VSX
 on:
   push:
-    branches:
-      - main
+    tags:
+      - '*'
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy to VS Marketplace
 on:
   push:
-    branches:
-      - main
+    tags:
+      - '*'
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should stop me from having heaps of workflow failed emails every time I push a dependency update.